### PR TITLE
[PBI-3651] Add secrets, move to local.properties, fix gradle

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,14 +1,24 @@
 apply plugin: 'com.android.application'
 
+def apiProperties = new Properties()
+if (project.rootProject.file('local.properties').exists()) {
+    apiProperties.load(project.rootProject.file('local.properties').newDataInputStream())
+}
+def mParticleKey = apiProperties["API_KEY"] ? apiProperties["API_KEY"] : ""
+def mParticleSecret = apiProperties["API_SECRET"] ? apiProperties["API_SECRET"] : ""
+
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
     defaultConfig {
         applicationId "com.apptentive.androidexample.mparticle"
-        minSdkVersion 19
-        targetSdkVersion 30
+        minSdkVersion 26
+        targetSdkVersion 31
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
+
+        buildConfigField "String", "MPARTICLE_KEY", mParticleKey
+        buildConfigField "String", "MPARTICLE_SECRET", mParticleSecret
     }
     buildTypes {
         release {
@@ -16,13 +26,20 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+
+    compileOptions
+            {
+                sourceCompatibility JavaVersion.VERSION_1_8
+                targetCompatibility JavaVersion.VERSION_1_8
+            }
 }
+
 
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     implementation 'androidx.appcompat:appcompat:1.0.0'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
-    implementation 'com.mparticle:android-core:5+'
+    implementation 'com.mparticle:android-core:5.44.2'
     implementation 'com.mparticle:android-apptentive-kit:5+'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,7 +10,8 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme.NoActionBar">
-        <activity android:name=".MainActivity">
+        <activity android:name=".MainActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/java/com/apptentive/androidexample/mparticle/ExampleApplication.java
+++ b/app/src/main/java/com/apptentive/androidexample/mparticle/ExampleApplication.java
@@ -9,9 +9,8 @@ public class ExampleApplication extends Application {
     @Override
     public void onCreate() {
         super.onCreate();
-
         MParticleOptions options = MParticleOptions.builder(this)
-                .credentials("YOUR_MPARTICLE_API_KEY","YOUR_MPARTICLE_API_SECRET")
+                .credentials(BuildConfig.MPARTICLE_KEY,BuildConfig.MPARTICLE_SECRET)
                 .logLevel(MParticle.LogLevel.VERBOSE)
                 .build();
         MParticle.start(options);

--- a/app/src/main/java/com/apptentive/androidexample/mparticle/MainActivity.java
+++ b/app/src/main/java/com/apptentive/androidexample/mparticle/MainActivity.java
@@ -107,6 +107,5 @@ public class MainActivity extends AppCompatActivity
     private void logEvent(String name, MParticle.EventType eventType) {
         MPEvent event = new MPEvent.Builder(name, eventType).build();
         MParticle.getInstance().logEvent(event);
-
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.1.3'
@@ -18,7 +18,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 


### PR DESCRIPTION
[PBI-3651](https://apptentive.atlassian.net/browse/PBI-3651)

This is not a fix for the issue overstock is experiencing. It is a sample app in working form. Fixed it to test and understand the issue.

Keys to add to `local.properties`
`API_KEY`
`API_SECRET`
Credentials are found in _1Password_ vault under "_mParticle Android example key and secret_”

